### PR TITLE
Update composition.py

### DIFF
--- a/brainpy/composition.py
+++ b/brainpy/composition.py
@@ -120,7 +120,7 @@ def parse_formula(formula):
         raise ValueError("%r does not look like a formula" % (formula,))
     composition = PyComposition()
     for elem, isotope, number in atom_pattern.findall(formula):
-        composition[_make_isotope_string(elem, int(isotope) if isotope else 0)] += int(number)
+        composition[_make_isotope_string(elem, int(isotope) if isotope else 0)] += int(number) if number else 1
     return composition
 
 


### PR DESCRIPTION
When you have a formula with only 1 atom of the element (let's say H2O or HPO4), the function "parse_formula(formula)" would crash in line 123 `composition[_make_isotope_string(elem, int(isotope) if isotope else 0)] += int(number)` with error: 

> ValueError: invalid literal for int() with base 10: ''

Changing the line to: `composition[_make_isotope_string(elem, int(isotope) if isotope else 0)] += int(number) if number else 1` fixes that error